### PR TITLE
Use cl-lib macro instead of cl.el

### DIFF
--- a/password-vault.el
+++ b/password-vault.el
@@ -97,10 +97,10 @@
 
   (let ((password-vault-buffer (get-buffer-create "*password-vault*")))
     (switch-to-buffer password-vault-buffer)
-    (loop for (key . value) in  password-vault-passwords
-          do
-          (password-vault-make-button (symbol-name key) value)
-          (insert "\n"))
+    (cl-loop for (key . value) in  password-vault-passwords
+             do
+             (password-vault-make-button (symbol-name key) value)
+             (insert "\n"))
     (goto-char (point-min))
     (password-vault-mode)))
 


### PR DESCRIPTION
This issue causes error at byte-compile as below.

```
Entering directory `/home/syohei/password-vault/'
password-vault.el:89:1:Error: Wrong type argument: listp, value
```